### PR TITLE
Create an actual diff of the formatting changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "vscode-test": "^1.2.2"
   },
   "dependencies": {
+    "@rauschma/stringio": "^1.4.0",
     "child_process": "^1.0.2",
     "diff": "^4.0.1",
     "untildify": "^4.0.0",


### PR DESCRIPTION
I had to open a new pull request, but this one finally seems to be working as intended.  In particular, it works with format-on-save turned on (which was broken with my last attempt).

Fixes #5.  Fixes #12.  Fixes #15.  Fixes #16.

* VSCode expects an array of `TextEdit` objects describing the
  formatting change to the file.  The Python extension this code is
  based off of obtains a unified diff from the formatting tool, and
  constructs a `TextEdit` array from this.  Because JuliaFormatter.jl
  does not produce diff output by default, we have to do it ourselves.
* Instead of using file I/O, the Julia process doing the formatting
  reads julia code from stdin, and writes the formatted code to
  stdout.  The typescript process then creates the requisite diff,
  formats it, and sends it back to vscode.
* This code is somewhat inefficient in that the diff undergoes two
  transformations (unified diff to ParsedDiff to TextEdit array), so
  a future optimization would be to create a TextEdit array directly
  from the comparison of the two files.  Alternatively,
  JuliaFormatter.jl could be updated to output a unified diff upon
  request.