### PR TITLE
Add BlueStyle option to style

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This extension contributes the following settings:
   expression where applicable in function definitions, macro definitions, and do blocks.
 * `juliaFormatter.compile`: Control the compilation level of Julia. Available values are
   'min' or 'all'.
-* `juliaFormatter.style`: Formatting styles. Choose from: `'default'` and `'yas'`.
+* `juliaFormatter.style`: Formatting styles. Choose from: `'default'`, `'yas'`, and `'blue'`.
 * `juliaFormatter.annotateUntypedFieldsWithAny`: If `true`, Annotates fields in a type
   definitions with `::Any` if no type annotation is provided (Requires
   `JuliaFormatter.jl v0.6.3`).

--- a/package.json
+++ b/package.json
@@ -62,9 +62,10 @@
           "default": "default",
           "enum": [
             "default",
-            "yas"
+            "yas",
+            "blue"
           ],
-          "description": "Formatting styles. Choose from: `'default'` and `'yas'`."
+          "description": "Formatting styles. Choose from: `'default'`, `'yas'`, and `'blue`'."
         },
         "juliaFormatter.whitespaceTypedefs": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,9 @@ export async function buildFormatArgs(): Promise<string[]> {
         case "yas":
             style = "YASStyle()";
             break;
+	case "blue":
+            style = "BlueStyle()";
+            break;
         default:
             style = "DefaultStyle()";
             break;


### PR DESCRIPTION
Seems like this is all that would be needed to be able to pick the [BlueStyle option](https://domluna.github.io/JuliaFormatter.jl/stable/blue_style/#JuliaFormatter.BlueStyle) in addition to the default and YAS styles? If so, I figured it might be nice to have the possibility.