### PR TITLE
Hotfix for bug where multiple statements outside of a module would ca…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,199 +1,199 @@
 {
-  "name": "vscode-julia-formatter",
-  "displayName": "Julia Formatter",
-  "publisher": "singularitti",
-  "icon": "icon.png",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/singularitti/vscode-julia-formatter"
-  },
-  "issues": {
-    "url": "https://github.com/singularitti/vscode-julia-formatter/issues"
-  },
-  "description": "A formatter for the Julia language",
-  "version": "0.6.0",
-  "engines": {
-    "vscode": "^1.40.0"
-  },
-  "categories": [
-    "Formatters"
-  ],
-  "activationEvents": [
-    "onLanguage:julia"
-  ],
-  "keywords": [
-    "julia",
-    "format",
-    "style"
-  ],
-  "main": "./out/extension.js",
-  "contributes": {
-    "configuration": {
-      "type": "object",
-      "title": "Julia Formatter configuration",
-      "properties": {
-        "juliaFormatter.overwriteFlags": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, accepts flag values passed from vs-code interface rather than default values of specified style."
-        },
-        "juliaFormatter.margin": {
-          "type": "number",
-          "default": 92,
-          "description": "The maximum number of characters of code on a single line. Lines over the limit will be wrapped if possible. There are cases where lines cannot be wrapped and they will still end up wider than the requested margin."
-        },
-        "juliaFormatter.alwaysForIn": {
-          "type": "boolean",
-          "default": false,
-          "description": "Always replaces `=` with `in` for `for` loops. For example, `for i = 1:10` will be transformed to `for i in 1:10`."
-        },
-        "juliaFormatter.indent": {
-          "type": "number",
-          "default": 4,
-          "description": "The number of spaces used for an indentation."
-        },
-        "juliaFormatter.compile": {
-          "type": "string",
-          "default": "min",
-          "enum": [
-            "min",
-            "all"
-          ],
-          "description": "Control the compilation level of Julia. Available values are 'min' or 'all'."
-        },
-        "juliaFormatter.style": {
-          "type": "string",
-          "default": "default",
-          "enum": [
-            "default",
-            "yas",
-            "blue"
-          ],
-          "description": "Formatting styles. Choose from: `'default'`, `'yas'`, and `'blue`'."
-        },
-        "juliaFormatter.whitespaceTypedefs": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, whitespace is added for type definitions. Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`."
-        },
-        "juliaFormatter.whitespaceOpsInIndices": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, whitespace is added for binary operations in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`."
-        },
-        "juliaFormatter.removeExtraNewlines": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, superflous newlines will be removed."
-        },
-        "juliaFormatter.importToUsing": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, `import` expressions are rewritten to `using` expressions."
-        },
-        "juliaFormatter.pipeToFunctionCall": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, `x |> f` is rewritten to `f(x)`."
-        },
-        "juliaFormatter.shortToLongFunctionDef": {
-          "type": "boolean",
-          "default": false,
-          "description": "Transforms a short function definition to a long function definition."
-        },
-        "juliaFormatter.alwaysUseReturn": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, `return` will be prepended to the last expression where applicable in function definitions, macro definitions, and do blocks."
-        },
-        "juliaFormatter.annotateUntypedFieldsWithAny": {
-          "type": "boolean",
-          "default": true,
-          "description": "If `true`, annotates fields in a type definitions with `::Any` if no type annotation is provided (Requires `JuliaFormatter.jl v0.6.3`)."
-        },
-        "juliaFormatter.whitespaceInKwargs": {
-          "type": "boolean",
-          "default": true,
-          "description": "If `true`, `=` in keyword arguments will be surrounded by whitespace."
-        },
-        "juliaFormatter.formatDocstrings": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, format code docstrings with the same options used for the code source."
-        },
-        "juliaFormatter.alignStructField": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, align struct field definitions to `::` or `=`, whichever has higher precedence."
-        },
-        "juliaFormatter.alignConditional": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, align conditional expressions to either `?`, `:`, or both."
-        },
-        "juliaFormatter.alignAssignment": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, align the `=`-like operators. This covers variable assignments and short definition functions."
-        },
-        "juliaFormatter.alignPairArrow": {
-          "type": "boolean",
-          "default": false,
-          "description": "If `true`, align pair arrows (`=>`)."
-        },
-        "juliaFormatter.conditionalToIf": {
-          "type": "boolean",
-          "default": false,
-          "description": "If the conditional `E ? A : B` exceeds the maximum margin converts it into the equivalent `if` block."
-        },
-        "juliaFormatter.normalizeLineEndings": {
-          "type": "string",
-          "default": "auto",
-          "enum": [
-            "auto",
-            "unix",
-            "windows"
-          ],
-          "description": "Normalize line endings."
-        },
-        "juliaFormatter.sysimagePath": {
-          "default": "",
-          "description": "The Julia system image to use with Julia's `--sysimage` argument. If left blank, no system image will be used.",
-          "type": "string"
-        }
-      }
-    }
-  },
-  "scripts": {
-    "vscode:prepublish": "npm run -S esbuild-base -- --minify",
-    "compile": "tsc -p ./",
-    "test-compile": "tsc -p ./",
-    "esbuild": "npm run -S esbuild-base -- --sourcemap",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
-    "esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
-    "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile",
-    "test": "node ./out/test/runTest.js"
-  },
-  "devDependencies": {
-    "@types/diff": "^4.0.2",
-    "@types/glob": "^7.1.1",
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^12.11.7",
-    "@types/vscode": "^1.40.0",
-    "esbuild": "^0.12.5",
-    "glob": "^7.1.5",
-    "mocha": "^6.2.2",
-    "tslint": "^5.20.0",
-    "typescript": "^4.1.3",
-    "vscode-test": "^1.2.2"
-  },
-  "dependencies": {
-    "@rauschma/stringio": "^1.4.0",
-    "child_process": "^1.0.2",
-    "diff": "^4.0.1",
-    "untildify": "^4.0.0",
-    "util": "^0.12.1"
-  }
+	"name": "vscode-julia-formatter",
+	"displayName": "Julia Formatter",
+	"publisher": "singularitti",
+	"icon": "icon.png",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/singularitti/vscode-julia-formatter"
+	},
+	"issues": {
+		"url": "https://github.com/singularitti/vscode-julia-formatter/issues"
+	},
+	"description": "A formatter for the Julia language",
+	"version": "0.6.1",
+	"engines": {
+		"vscode": "^1.40.0"
+	},
+	"categories": [
+		"Formatters"
+	],
+	"activationEvents": [
+		"onLanguage:julia"
+	],
+	"keywords": [
+		"julia",
+		"format",
+		"style"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Julia Formatter configuration",
+			"properties": {
+				"juliaFormatter.overwriteFlags": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, accepts flag values passed from vs-code interface rather than default values of specified style."
+				},
+				"juliaFormatter.margin": {
+					"type": "number",
+					"default": 92,
+					"description": "The maximum number of characters of code on a single line. Lines over the limit will be wrapped if possible. There are cases where lines cannot be wrapped and they will still end up wider than the requested margin."
+				},
+				"juliaFormatter.alwaysForIn": {
+					"type": "boolean",
+					"default": false,
+					"description": "Always replaces `=` with `in` for `for` loops. For example, `for i = 1:10` will be transformed to `for i in 1:10`."
+				},
+				"juliaFormatter.indent": {
+					"type": "number",
+					"default": 4,
+					"description": "The number of spaces used for an indentation."
+				},
+				"juliaFormatter.compile": {
+					"type": "string",
+					"default": "min",
+					"enum": [
+						"min",
+						"all"
+					],
+					"description": "Control the compilation level of Julia. Available values are 'min' or 'all'."
+				},
+				"juliaFormatter.style": {
+					"type": "string",
+					"default": "default",
+					"enum": [
+						"default",
+						"yas",
+						"blue"
+					],
+					"description": "Formatting styles. Choose from: `'default'`, `'yas'`, and `'blue`'."
+				},
+				"juliaFormatter.whitespaceTypedefs": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, whitespace is added for type definitions. Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`."
+				},
+				"juliaFormatter.whitespaceOpsInIndices": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, whitespace is added for binary operations in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`."
+				},
+				"juliaFormatter.removeExtraNewlines": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, superflous newlines will be removed."
+				},
+				"juliaFormatter.importToUsing": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, `import` expressions are rewritten to `using` expressions."
+				},
+				"juliaFormatter.pipeToFunctionCall": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, `x |> f` is rewritten to `f(x)`."
+				},
+				"juliaFormatter.shortToLongFunctionDef": {
+					"type": "boolean",
+					"default": false,
+					"description": "Transforms a short function definition to a long function definition."
+				},
+				"juliaFormatter.alwaysUseReturn": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, `return` will be prepended to the last expression where applicable in function definitions, macro definitions, and do blocks."
+				},
+				"juliaFormatter.annotateUntypedFieldsWithAny": {
+					"type": "boolean",
+					"default": true,
+					"description": "If `true`, annotates fields in a type definitions with `::Any` if no type annotation is provided (Requires `JuliaFormatter.jl v0.6.3`)."
+				},
+				"juliaFormatter.whitespaceInKwargs": {
+					"type": "boolean",
+					"default": true,
+					"description": "If `true`, `=` in keyword arguments will be surrounded by whitespace."
+				},
+				"juliaFormatter.formatDocstrings": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, format code docstrings with the same options used for the code source."
+				},
+				"juliaFormatter.alignStructField": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, align struct field definitions to `::` or `=`, whichever has higher precedence."
+				},
+				"juliaFormatter.alignConditional": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, align conditional expressions to either `?`, `:`, or both."
+				},
+				"juliaFormatter.alignAssignment": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, align the `=`-like operators. This covers variable assignments and short definition functions."
+				},
+				"juliaFormatter.alignPairArrow": {
+					"type": "boolean",
+					"default": false,
+					"description": "If `true`, align pair arrows (`=>`)."
+				},
+				"juliaFormatter.conditionalToIf": {
+					"type": "boolean",
+					"default": false,
+					"description": "If the conditional `E ? A : B` exceeds the maximum margin converts it into the equivalent `if` block."
+				},
+				"juliaFormatter.normalizeLineEndings": {
+					"type": "string",
+					"default": "auto",
+					"enum": [
+						"auto",
+						"unix",
+						"windows"
+					],
+					"description": "Normalize line endings."
+				},
+				"juliaFormatter.sysimagePath": {
+					"default": "",
+					"description": "The Julia system image to use with Julia's `--sysimage` argument. If left blank, no system image will be used.",
+					"type": "string"
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run -S esbuild-base -- --minify",
+		"compile": "tsc -p ./",
+		"test-compile": "tsc -p ./",
+		"esbuild": "npm run -S esbuild-base -- --sourcemap",
+		"esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+		"esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
+		"watch": "tsc -watch -p ./",
+		"pretest": "npm run compile",
+		"test": "node ./out/test/runTest.js"
+	},
+	"devDependencies": {
+		"@types/diff": "^4.0.2",
+		"@types/glob": "^7.1.1",
+		"@types/mocha": "^5.2.7",
+		"@types/node": "^12.11.7",
+		"@types/vscode": "^1.40.0",
+		"esbuild": "^0.12.5",
+		"glob": "^7.1.5",
+		"mocha": "^6.2.2",
+		"tslint": "^5.20.0",
+		"typescript": "^4.1.3",
+		"vscode-test": "^1.2.2"
+	},
+	"dependencies": {
+		"@rauschma/stringio": "^1.4.0",
+		"child_process": "^1.0.2",
+		"diff": "^4.0.1",
+		"untildify": "^4.0.0",
+		"util": "^0.12.1"
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ export async function buildFormatArgs(): Promise<string[]> {
         `using JuliaFormatter
 
         const file_contents = read(stdin, String)
-        Meta.parse(file_contents)
+        Meta.parseall(file_contents)
 
         function format_stdin()
             print(format_text(file_contents; ${options}))


### PR DESCRIPTION
…use formatting to fail (replaced Meta.parse, which can only handle one expression, with Meta.parseall)